### PR TITLE
Remove thinid (diana.js)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list.
 * [uid-safe](https://github.com/crypto-utils/uid-safe) ([npm](https://www.npmjs.com/package/uid-safe)) - URL and cookie safe UIDs.
 * [nanoid](https://github.com/ai/nanoid) ([npm](https://www.npmjs.com/package/nanoid)) - A tiny, secure, URL-friendly, unique string ID generator for JavaScript.
 * [ObjectId](https://docs.mongodb.com/manual/reference/method/ObjectId/) ([github](https://github.com/mongodb/js-bson/blob/1.0-branch/lib/bson/objectid.js)) - MongoDBs ObjectId
-* [thinid](https://github.com/cuongw/thinid) ([npm](https://www.npmjs.com/package/thinid)) - Easy way to create unique ids.
 * [uuid-readable](https://github.com/Debdut/uuid-readable) ([npm](https://www.npmjs.com/package/uuid-readable)) - Generate Easy to Remember, Readable UUIDs, that are Shakespearean and Gramatically Correct Sentences.
 * [human-readable-ids](https://git.coolaj86.com/coolaj86/human-readable-ids.js.git) ([npm](https://www.npmjs.com/package/human-readable-ids)) - Use JavaScript to generate human-readable ids from a list of nouns and adjectives.
 * [ksuid](https://github.com/segmentio/ksuid) ([npm](https://www.npmjs.com/package/ksuid)) - K-Sortable Globally Unique IDs.


### PR DESCRIPTION
Remove thinid, it uses Math.random() for getting random numbers so it's cryptographically insecure and uses non url safe characters which makes it useless, since in node environment you can easily use Crypto for random number generation. Also generates many random numbers every function call which hurts performance